### PR TITLE
fix rel4 kernel binary mode intergration bugs

### DIFF
--- a/build-bin.sh
+++ b/build-bin.sh
@@ -24,6 +24,10 @@ fi
 cd rel4_kernel/kernel
 cargo update -p home --precise 0.5.5
 cargo build --release --target aarch64-unknown-none-softfloat -F ENABLE_SMC --bin rel4_kernel -F BUILD_BINARY
+# install rel4 kernel
+mkdir -p $REL4_PREFIX/bin/
+cp ../target/aarch64-unknown-none-softfloat/release/rel4_kernel $REL4_PREFIX/bin/kernel.elf
+
 cd ../../kernel
 cmake \
     -DCROSS_COMPILER_PREFIX=aarch64-linux-gnu- \


### PR DESCRIPTION
将 rel4 kernel 编出来的 binary 拷贝到 kit/.env/bin 下，这样加载使用的是 binary 模式编出来的 kernel.elf
适配这个改动，sel4_impl 中有个相应的 commit 
https://github.com/reL4team2/seL4_c_impl/commit/7c1224a890f4e0a140cb683b5e98925d8ef59fef

顺带说一句，目前只有 kernel.elf 是和 sel4 kernel 完全无关的，其他的如 libsel4, kernel.dtb 等，还是 seL4 kernel 提供的